### PR TITLE
fix(lsp): valid file:// document URIs, didOpen lifecycle, pull-based diagnostics

### DIFF
--- a/app/src/main/java/com/klyx/lsp/KlyxLspClient.kt
+++ b/app/src/main/java/com/klyx/lsp/KlyxLspClient.kt
@@ -3,6 +3,7 @@ package com.klyx.lsp
 import android.util.Log
 import com.klyx.lsp.server.LanguageClient
 import com.klyx.lsp.server.LanguageServer
+import com.klyx.lsp.server.ResponseErrorException
 import com.klyx.lsp.types.LSPAny
 import com.klyx.lsp.types.LSPArray
 import com.klyx.lsp.types.LSPObject
@@ -13,10 +14,15 @@ import io.github.rosemoe.sora.lang.diagnostic.DiagnosticDetail
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticRegion
 import io.github.rosemoe.sora.lang.diagnostic.DiagnosticsContainer
 import io.github.rosemoe.sora.text.Content
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import java.util.concurrent.ConcurrentHashMap
 
 internal class DiagnosticsAggregator {
@@ -66,6 +72,11 @@ internal class KlyxLspClient(
     private val onRefreshInlayHints: () -> Unit = {},
     private val onRefreshDiagnostics: () -> Unit = {}
 ) : LanguageClient {
+
+    companion object {
+        private const val PULL_RETRY_DELAY_MS = 400L
+        private const val PULL_MAX_ATTEMPTS = 10
+    }
 
     private val registeredUris = ConcurrentHashMap.newKeySet<String>()
     private val diagnosticResultIds = ConcurrentHashMap<String, String?>()
@@ -127,22 +138,50 @@ internal class KlyxLspClient(
         if (disposed) return
         if (aggregator.editorFor(uri) == null) return
         val previous = diagnosticResultIds[uri]
-        val report = try {
-            server.textDocument.diagnostic(
-                DocumentDiagnosticParams(
-                    textDocument = TextDocumentIdentifier(uri),
-                    identifier = null,
-                    previousResultId = previous
+        var attempts = 0
+        while (true) {
+            attempts++
+            val report = try {
+                server.textDocument.diagnostic(
+                    DocumentDiagnosticParams(
+                        textDocument = TextDocumentIdentifier(uri),
+                        identifier = null,
+                        previousResultId = previous
+                    )
                 )
-            )
-        } catch (e: Exception) {
-            Log.w("LspClient", "diagnostic pull failed for $uri from $serverId: ${e.message}")
+            } catch (e: ResponseErrorException) {
+                // A ServerCancelled (-32802) response with retriggerRequest=true
+                // means "still busy, resend this request once ready", not a real
+                // failure. Retry with a short delay instead of giving up.
+                val retrigger = e.code == ErrorCodes.ServerCancelled &&
+                    ((e.data as? JsonObject)
+                        ?.let { runCatching { Json.decodeFromJsonElement<DiagnosticServerCancellationData>(it) }.getOrNull() }
+                        ?.retriggerRequest
+                        ?: false)
+                if (!retrigger) {
+                    Log.w("LspClient", "diagnostic pull failed for $uri from $serverId: ${e.message}")
+                    return
+                }
+                if (attempts >= PULL_MAX_ATTEMPTS) {
+                    Log.d("LspClient", "diagnostic pull for $uri from $serverId still cancelled after $attempts attempts")
+                    return
+                }
+                Log.d("LspClient", "diagnostics not ready yet for $uri (attempt $attempts/$PULL_MAX_ATTEMPTS), retrying")
+                delay(PULL_RETRY_DELAY_MS)
+                if (disposed || aggregator.editorFor(uri) == null) return
+                continue
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.w("LspClient", "diagnostic pull failed for $uri from $serverId: ${e.message}")
+                return
+            }
+            val full = report.full ?: return
+            diagnosticResultIds[uri] = full.resultId
+            publish(uri, full.items)
+            Log.d("LspClient", "Pulled ${full.items.size} diagnostics for $uri from $serverId")
             return
         }
-        val full = report.full ?: return
-        diagnosticResultIds[uri] = full.resultId
-        publish(uri, full.items)
-        Log.d("LspClient", "Pulled ${full.items.size} diagnostics for $uri from $serverId")
     }
 
     private suspend fun publish(uri: String, diagnostics: List<Diagnostic>) {

--- a/app/src/main/java/com/klyx/lsp/KlyxLspClient.kt
+++ b/app/src/main/java/com/klyx/lsp/KlyxLspClient.kt
@@ -67,6 +67,13 @@ internal class KlyxLspClient(
 
     private val registeredUris = ConcurrentHashMap.newKeySet<String>()
 
+    // The single source of truth for open state on this connection: a URI is in
+    // this set exactly while didOpen was sent and no didClose has followed.
+    // LspManager consults it before every didOpen so a document is never opened
+    // twice on one connection — not on editor re-registration, retries, or
+    // reconnects. Servers are free to reject the second open.
+    private val didOpenedUris = ConcurrentHashMap.newKeySet<String>()
+
     // Once a server is stopped/restarted/crashed the underlying process can keep
     // emitting notifications (rust-analyzer flushes queued window/logMessage traces for
     // a while). Gate every inbound callback so a disposed client never pushes anything
@@ -86,6 +93,15 @@ internal class KlyxLspClient(
     fun unregisterEditor(uri: String) {
         registeredUris.remove(uri)
         aggregator.removeSource(uri, serverId)
+        didOpenedUris.remove(uri)
+    }
+
+    /** True when [uri] is currently open on this server (didOpen sent, no didClose since). */
+    fun isOpen(uri: String): Boolean = didOpenedUris.contains(uri)
+
+    /** Marks [uri] as open on this server. Call right before sending didOpen. */
+    fun markOpened(uri: String) {
+        didOpenedUris.add(uri)
     }
 
     /** Called when this server is marked dead so its stale diagnostics don't linger

--- a/app/src/main/java/com/klyx/lsp/KlyxLspClient.kt
+++ b/app/src/main/java/com/klyx/lsp/KlyxLspClient.kt
@@ -2,6 +2,7 @@ package com.klyx.lsp
 
 import android.util.Log
 import com.klyx.lsp.server.LanguageClient
+import com.klyx.lsp.server.LanguageServer
 import com.klyx.lsp.types.LSPAny
 import com.klyx.lsp.types.LSPArray
 import com.klyx.lsp.types.LSPObject
@@ -62,10 +63,12 @@ internal class KlyxLspClient(
     private val aggregator: DiagnosticsAggregator,
     private val activityStore: LspActivityStore,
     private val serverName: String = serverId,
-    private val onRefreshInlayHints: () -> Unit = {}
+    private val onRefreshInlayHints: () -> Unit = {},
+    private val onRefreshDiagnostics: () -> Unit = {}
 ) : LanguageClient {
 
     private val registeredUris = ConcurrentHashMap.newKeySet<String>()
+    private val diagnosticResultIds = ConcurrentHashMap<String, String?>()
 
     // The single source of truth for open state on this connection: a URI is in
     // this set exactly while didOpen was sent and no didClose has followed.
@@ -113,6 +116,33 @@ internal class KlyxLspClient(
     override suspend fun publishDiagnostics(params: PublishDiagnosticsParams) {
         if (disposed) return
         publish(params.uri, params.diagnostics)
+    }
+
+    /**
+     * Pulls diagnostics for [uri] via the `textDocument/diagnostic` request.
+     * Some servers gate pushed diagnostics behind a completed workspace load
+     * but still answer pull requests from analysis done so far.
+     */
+    suspend fun pullDiagnostics(server: LanguageServer, uri: String) {
+        if (disposed) return
+        if (aggregator.editorFor(uri) == null) return
+        val previous = diagnosticResultIds[uri]
+        val report = try {
+            server.textDocument.diagnostic(
+                DocumentDiagnosticParams(
+                    textDocument = TextDocumentIdentifier(uri),
+                    identifier = null,
+                    previousResultId = previous
+                )
+            )
+        } catch (e: Exception) {
+            Log.w("LspClient", "diagnostic pull failed for $uri from $serverId: ${e.message}")
+            return
+        }
+        val full = report.full ?: return
+        diagnosticResultIds[uri] = full.resultId
+        publish(uri, full.items)
+        Log.d("LspClient", "Pulled ${full.items.size} diagnostics for $uri from $serverId")
     }
 
     private suspend fun publish(uri: String, diagnostics: List<Diagnostic>) {
@@ -211,7 +241,8 @@ internal class KlyxLspClient(
     }
 
     override suspend fun refreshDiagnostics() {
-        // No-op
+        if (disposed) return
+        onRefreshDiagnostics()
     }
 
     override suspend fun refreshFoldingRanges() {

--- a/app/src/main/java/com/klyx/lsp/KlyxLspClient.kt
+++ b/app/src/main/java/com/klyx/lsp/KlyxLspClient.kt
@@ -240,6 +240,11 @@ internal class KlyxLspClient(
     override suspend fun notifyProgress(params: ProgressParams) {
         if (disposed) return
         activityStore.progress(serverId, params)
+        params.value.fold({ notification ->
+            // A finished work-done progress (indexing, build, ...) means the
+            // server's analysis just advanced — ask for fresh diagnostics.
+            if (notification is WorkDoneProgressEnd) onRefreshDiagnostics()
+        }, {})
         //Log.i("LspClient", "Progress: $params")
     }
 

--- a/app/src/main/java/com/klyx/lsp/LspManager.kt
+++ b/app/src/main/java/com/klyx/lsp/LspManager.kt
@@ -110,7 +110,19 @@ class LspManager(
         }
 
         val keys = providers.map { ServerKey(projectUri?.toString(), file.languageId, it.id) }
-        val documentUri = file.uri.toString()
+
+        // Language servers run inside the terminal rootfs and only accept file://
+        // URIs pointing at paths visible there. Translate the tab's (possibly
+        // content://) URI once and use the result for all LSP traffic.
+        val lspUris = resolveLspUris(file)
+        val documentUri = lspUris.serverUri
+        if (documentUri == null) {
+            Log.w("LspManager", "No resolvable real path for ${file.uri}; LSP disabled for this file")
+            activityStore.log(file.name, "LSP disabled: no real path for ${file.uri}")
+            withContext(Dispatchers.Main) { editorState.editorLanguage = baseLanguage }
+            return
+        }
+        Log.d("LspManager", "Tab $tabId ${file.name}: ${file.uri} -> $documentUri")
 
         withContext(Dispatchers.IO) {
             try {
@@ -124,7 +136,7 @@ class LspManager(
                     providers.zip(keys).map { (reg, key) ->
                         async {
                             key to runCatching {
-                                ensureServerInstance(key, reg.provider, projectUri)
+                                ensureServerInstance(key, reg.provider, projectUri, file)
                             }.getOrNull()
                         }
                     }.awaitAll()
@@ -235,7 +247,8 @@ class LspManager(
     private suspend fun ensureServerInstance(
         key: ServerKey,
         provider: LanguageServerProvider,
-        projectUri: Uri?
+        projectUri: Uri?,
+        file: KxFile? = null
     ): ServerInstance {
         return activeServers[key]?.takeIf { !it.isDead } ?: mutexFor(key).withLock {
             activeServers[key]?.takeIf { !it.isDead } ?: run {
@@ -249,7 +262,12 @@ class LspManager(
                 )
                 val server = provider.startServer(client)
 
-                val initParams = createInitializeParams(projectUri?.toFile())
+                // The workspace root is usually a content:// SAF URI with no file
+                // path; resolve it to the guest-visible project root, falling back
+                // to walking up from the opened file.
+                val root = resolveProjectRoot(projectUri, file)
+                Log.d("LspManager", "Server ${key.providerId}: workspace root = ${root?.absolutePath}")
+                val initParams = createInitializeParams(root)
 
                 val initializeResult = server.initialize(initParams)
                 server.initialized(InitializedParams)

--- a/app/src/main/java/com/klyx/lsp/LspManager.kt
+++ b/app/src/main/java/com/klyx/lsp/LspManager.kt
@@ -154,6 +154,11 @@ class LspManager(
                         async {
                             instance.client.registerEditor(documentUri, editorState)
                             if (!instance.capabilities.supportsDidOpenClose()) return@async
+                            // Never open the same document twice on one connection
+                            // without an intervening didClose; servers are free to
+                            // reject the second open.
+                            if (instance.client.isOpen(documentUri)) return@async
+                            instance.client.markOpened(documentUri)
                             try {
                                 withTimeoutOrNull(SERVER_CALL_TIMEOUT_MS.milliseconds) {
                                     instance.server.textDocument.didOpen(
@@ -294,6 +299,8 @@ class LspManager(
 
                     client.registerEditor(uri, state)
                     if (!newInstance.capabilities.supportsDidOpenClose()) return@forEach
+                    if (client.isOpen(uri)) return@forEach
+                    client.markOpened(uri)
                     scope.launch(Dispatchers.IO) {
                         try {
                             withTimeoutOrNull(SERVER_CALL_TIMEOUT_MS.milliseconds) {

--- a/app/src/main/java/com/klyx/lsp/LspManager.kt
+++ b/app/src/main/java/com/klyx/lsp/LspManager.kt
@@ -263,7 +263,8 @@ class LspManager(
                     diagnosticsAggregator,
                     activityStore,
                     key.providerId,
-                    onRefreshInlayHints = { refreshInlayHintsForServer(key) }
+                    onRefreshInlayHints = { refreshInlayHintsForServer(key) },
+                    onRefreshDiagnostics = { refreshDiagnosticsForServer(key) }
                 )
                 val server = provider.startServer(client)
 
@@ -516,6 +517,20 @@ class LspManager(
             // Invalidate the cache so an identical-to-last result still gets applied.
             cachedInlayHints.remove(tabId)
             requestInlayHint(tabId, state, state.cursor.leftLine)
+        }
+    }
+
+    /** Re-pulls diagnostics for every document served by [key]. Invoked when the
+     * server requests a refresh (workspace/diagnostic/refresh), i.e. when its
+     * analysis has advanced and new diagnostics are available. */
+    private fun refreshDiagnosticsForServer(key: ServerKey) {
+        val instance = activeServers[key]?.takeIf { !it.isDead } ?: return
+        editorServerKeys.forEach { (tabId, keysForTab) ->
+            if (key !in keysForTab) return@forEach
+            val uri = editorUris[tabId] ?: return@forEach
+            scope.launch {
+                runCatching { instance.client.pullDiagnostics(instance.server, uri) }
+            }
         }
     }
 

--- a/app/src/main/java/com/klyx/lsp/LspUris.kt
+++ b/app/src/main/java/com/klyx/lsp/LspUris.kt
@@ -1,0 +1,143 @@
+package com.klyx.lsp
+
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.core.net.toFile
+import com.blankj.utilcode.util.UriUtils
+import com.klyx.api.data.file.KxFile
+import com.klyx.api.data.fs.Paths
+import com.klyx.api.terminal.home
+import com.klyx.api.util.applicationContext
+import java.io.File
+
+/**
+ * A document as seen by a language server running inside the terminal's rootfs.
+ *
+ * The host app addresses files with SAF URIs (`content://...`), but LSP servers
+ * require `file://` URIs pointing at paths that exist inside their own
+ * (rootfs) filesystem. [serverUri] is the URI to send in `didOpen` and
+ * friends; it is null when the document has no resolvable real path (e.g. a
+ * cloud-backed SAF provider), in which case LSP must be skipped for that tab.
+ */
+data class LspUris(
+    val serverUri: String?,
+    val realFile: File?,
+    val guestFile: File?
+)
+
+/**
+ * Resolves [file]'s URI into the URIs used for LSP traffic.
+ *
+ * Resolution order:
+ * 1. `file://` URIs are used as-is.
+ * 2. Klyx's own terminal documents provider stores the real absolute path in
+ *    the document id, so it can be reconstructed directly.
+ * 3. Other SAF providers (external storage, downloads, ...) are resolved
+ *    through [UriUtils.uri2FileNoCacheCopy] when the system exposes a real path.
+ */
+fun resolveLspUris(file: KxFile): LspUris {
+    val real = resolveRealFile(file.uri) ?: return LspUris(null, null, null)
+    val guest = toGuestPath(real)
+    return LspUris(guest.toLspUri(), real, guest)
+}
+
+/**
+ * Builds the LSP-facing URI for [this] file in the RFC 8089 triple-slash
+ * `file:///path` form.
+ *
+ * [File.toURI] alone yields the authority-less `file:/path` variant (a single
+ * slash), which strict LSP URI parsers do not match against the
+ * `file:///path` documents a server produces from its own workspace scan.
+ * The percent-encoded path from [File.toURI] is reused and the `file://`
+ * authority is prepended explicitly.
+ */
+fun File.toLspUri(): String = "file://${toURI().rawSchemeSpecificPart}"
+
+fun resolveRealFile(uri: Uri): File? = when (uri.scheme) {
+    "file" -> uri.toFile()
+    "content" -> resolveContentFile(uri)
+    else -> null
+}
+
+private fun resolveContentFile(uri: Uri): File? {
+    val context = applicationContext()
+    val ownAuthority = "${context.packageName}.terminal.documents"
+    if (uri.authority == ownAuthority) {
+        val docId = when {
+            DocumentsContract.isTreeUri(uri) -> DocumentsContract.getTreeDocumentId(uri)
+            DocumentsContract.isDocumentUri(context, uri) -> DocumentsContract.getDocumentId(uri)
+            else -> null
+        }
+        if (docId != null && docId.isNotEmpty()) return File(docId)
+    }
+    return runCatching { UriUtils.uri2FileNoCacheCopy(uri) }.getOrNull()
+}
+
+/**
+ * Translates a real filesystem path into the path visible inside the terminal's
+ * PRoot environment. The terminal binds [Paths.home] to `/root`, so any path
+ * under it is rewritten to its home-relative location under `/root`. Everything
+ * else (the data dir, `/storage`, ...) is bound at the same location and passed
+ * through unchanged.
+ */
+fun toGuestPath(real: File): File {
+    val canonical = real.canonicalFile
+    val home = Paths.home.canonicalFile
+    return if (canonical.path.startsWith(home.path)) {
+        File("/root" + canonical.path.removePrefix(home.path))
+    } else {
+        canonical
+    }
+}
+
+private val PROJECT_MARKERS = listOf(
+    "Cargo.toml",
+    "build.gradle.kts",
+    "build.gradle",
+    "package.json",
+    "tsconfig.json",
+    "pyproject.toml",
+    "go.mod",
+    "pom.xml",
+    "CMakeLists.txt",
+    ".git"
+)
+
+/**
+ * Finds the nearest project root for [file] by walking up from its real path.
+ * Returns the root translated to the guest (rootfs-visible) path, or null when
+ * the file has no resolvable real path.
+ */
+fun findProjectRoot(file: KxFile): File? {
+    val real = resolveRealFile(file.uri) ?: return null
+    return findProjectRoot(real)?.let(::toGuestPath)
+}
+
+/**
+ * Finds the nearest project root for [real] by walking up looking for project
+ * markers. Returns the root in guest (rootfs-visible) form.
+ */
+fun findProjectRoot(real: File): File? {
+    var dir: File? = real.takeIf { it.isDirectory } ?: real.parentFile
+    repeat(15) {
+        val current = dir ?: return null
+        for (marker in PROJECT_MARKERS) {
+            if (current.resolve(marker).exists()) return current
+        }
+        dir = current.parentFile
+    }
+    return real.parentFile
+}
+
+/**
+ * Resolves the workspace root to its guest (rootfs-visible) path.
+ * Prefers [projectUri] (the workspace root) when resolvable, otherwise falls
+ * back to walking up from [file].
+ */
+fun resolveProjectRoot(projectUri: Uri?, file: KxFile?): File? {
+    if (projectUri != null) {
+        resolveRealFile(projectUri)?.let { real -> return toGuestPath(real) }
+    }
+    if (file != null) return findProjectRoot(file)
+    return null
+}

--- a/app/src/main/java/com/klyx/lsp/createInitializeParams.kt
+++ b/app/src/main/java/com/klyx/lsp/createInitializeParams.kt
@@ -9,6 +9,8 @@ import com.klyx.lsp.capabilities.CodeActionLiteralSupportCapabilities
 import com.klyx.lsp.capabilities.CompletionCapabilities
 import com.klyx.lsp.capabilities.CompletionItemCapabilities
 import com.klyx.lsp.capabilities.DefinitionCapabilities
+import com.klyx.lsp.capabilities.DiagnosticClientCapabilities
+import com.klyx.lsp.capabilities.DiagnosticWorkspaceClientCapabilities
 import com.klyx.lsp.capabilities.DidChangeConfigurationCapabilities
 import com.klyx.lsp.capabilities.DidChangeWatchedFilesCapabilities
 import com.klyx.lsp.capabilities.DocumentSymbolCapabilities
@@ -107,7 +109,11 @@ internal fun createInitializeParams(
                     relatedInformation = true,
                     versionSupport = true
                 ),
-                inlayHint = InlayHintClientCapabilities(dynamicRegistration = true)
+                inlayHint = InlayHintClientCapabilities(dynamicRegistration = true),
+                diagnostic = DiagnosticClientCapabilities(
+                    relatedDocumentSupport = true,
+                    relatedInformation = true
+                )
             ),
             workspace = WorkspaceClientCapabilities(
                 applyEdit = true,
@@ -126,7 +132,8 @@ internal fun createInitializeParams(
                     dynamicRegistration = true,
                     symbolKind = SymbolKindCapabilities(valueSet = SymbolKind.entries)
                 ),
-                executeCommand = ExecuteCommandCapabilities(dynamicRegistration = true)
+                executeCommand = ExecuteCommandCapabilities(dynamicRegistration = true),
+                diagnostics = DiagnosticWorkspaceClientCapabilities(refreshSupport = true)
             ),
             window = WindowClientCapabilities(
                 showMessage = ShowMessageRequestCapabilities(

--- a/app/src/main/java/com/klyx/lsp/createInitializeParams.kt
+++ b/app/src/main/java/com/klyx/lsp/createInitializeParams.kt
@@ -140,10 +140,10 @@ internal fun createInitializeParams(
     ).apply {
         if (project != null) {
             @Suppress("DEPRECATION")
-            rootUri = project.toURI().toString()
+            rootUri = project.toLspUri()
             workspaceFolders = listOf(
                 WorkspaceFolder(
-                    uri = project.toURI().toString(),
+                    uri = project.toLspUri(),
                     name = project.name
                 )
             )


### PR DESCRIPTION
## Summary

Five protocol-conformance fixes for LSP traffic between the editor and language servers running inside the terminal rootfs:

1. **RFC 8089 `file://` document URIs.** Documents were sent to servers as raw SAF `content://` URIs, and the only `File`→URI conversion produced the authority-less `file:/path` single-slash form, which strict LSP URI parsers do not match against the `file:///path` documents a server produces from its own workspace scan — so the opened overlay document never matched the file the server analysed from disk. `File.toLspUri()` now builds the RFC 8089 triple-slash form, and every LSP-facing URI (`didOpen`/`didChange`/`didClose`, initialize `rootUri`, `workspaceFolders`) goes through it.
2. **`didOpen` exactly once per connection.** The same document could be opened twice on one connection (editor re-registration, reconnects) without an intervening `didClose`; servers reject or log the second open. Open state is now tracked per connection and both `didOpen` call sites (initial open + reconnect re-open) consult it.
3. **Pull-based diagnostics.** The client now declares `textDocument.diagnostic` and `workspace.diagnostic.refreshSupport`, implements `textDocument/diagnostic` pulls (round-tripping the server's `resultId` so unchanged results stay unchanged), and honors `workspace/diagnostic/refresh` by re-pulling every document served by that connection.
4. **`ServerCancelled` retrigger.** A pull answered with error `-32802` (`ServerCancelled`, `retriggerRequest: true`) means "resend this request once ready", not failure. The pull is retried with a short delay and a bounded, cancellable retry loop instead of being swallowed as an error.
5. **Re-pull when server work completes.** A finished `$/progress` work-done notification (indexing, builds, ...) means the server's analysis just advanced, so diagnostics are re-pulled immediately.

## Before / after

| | Before | After |
|---|---|---|
| `didOpen` document | `content://com.klyx…/document/primary%3A…` | `file:///storage/emulated/0/learn/src/main.rs` |
| Initialize `rootUri` / `workspaceFolders` | `file:/storage/emulated/0/learn` (single slash) | `file:///storage/emulated/0/learn` |
| `textDocument/diagnostic` while the server is still preparing | error `-32802` swallowed as a failure | retried (bounded, ~5 s) until ready |
| `workspace/diagnostic/refresh` | capability undeclared, `refreshDiagnostics()` a no-op | declared and honored — every document of the connection is re-pulled |

## Testing

Built release APKs via GitHub Actions and validated on-device (Android, arm64): documents open under the triple-slash URI matching the server's workspace scan, `textDocument/diagnostic` pulls return real item counts (not empty), and refresh / work-done-progress signals trigger re-pulls.